### PR TITLE
Delete tooling_repos.yml

### DIFF
--- a/tooling_repos.yml
+++ b/tooling_repos.yml
@@ -1,5 +1,0 @@
-github:
-#    - https://github.com/protontypes/libreselery
-#    - https://github.com/torvalds/linux
-#    - https://github.com/python/cpython
-    - https://github.com/docker/docker-ce


### PR DESCRIPTION
Tooling is disabled in the selery.yml and should not confuse new users using the template with this file. Therefore I removed the file.